### PR TITLE
Fix: Update reCAPTCHA v3 site key

### DIFF
--- a/promo-1hora.html
+++ b/promo-1hora.html
@@ -25,7 +25,7 @@
     <link rel="stylesheet" href="assets/css/style.css">
     <script src="https://cdnjs.cloudflare.com/ajax/libs/modernizr/3.13.1/modernizr.min.js"></script>
     <!-- Script do Google reCAPTCHA v3 -->
-    <script src="https://www.google.com/recaptcha/api.js?render=6LfqMsYrAAAAAOXpg4f5HpKyW71cRDhqfeAoRt2J"></script>
+    <script src="https://www.google.com/recaptcha/api.js?render=6LcFeM8rAAAAAG_yvOemcZ1ivd14z9svaddS0Bk1"></script>
 </head>
 <body>
     <div class="countdown-banner sticky">

--- a/promo-2por299.html
+++ b/promo-2por299.html
@@ -25,7 +25,7 @@
     <link rel="stylesheet" href="assets/css/style.css">
     <script src="https://cdnjs.cloudflare.com/ajax/libs/modernizr/3.13.1/modernizr.min.js"></script>
     <!-- Script do Google reCAPTCHA v3 -->
-    <script src="https://www.google.com/recaptcha/api.js?render=6LfqMsYrAAAAAOXpg4f5HpKyW71cRDhqfeAoRt2J"></script>
+    <script src="https://www.google.com/recaptcha/api.js?render=6LcFeM8rAAAAAG_yvOemcZ1ivd14z9svaddS0Bk1"></script>
 </head>
 <body>
     <div class="countdown-banner sticky">

--- a/promo-antirreflexo.html
+++ b/promo-antirreflexo.html
@@ -25,7 +25,7 @@
     <link rel="stylesheet" href="assets/css/style.css">
     <script src="https://cdnjs.cloudflare.com/ajax/libs/modernizr/3.13.1/modernizr.min.js"></script>
     <!-- Script do Google reCAPTCHA v3 -->
-    <script src="https://www.google.com/recaptcha/api.js?render=6LfqMsYrAAAAAOXpg4f5HpKyW71cRDhqfeAoRt2J"></script>
+    <script src="https://www.google.com/recaptcha/api.js?render=6LcFeM8rAAAAAG_yvOemcZ1ivd14z9svaddS0Bk1"></script>
 </head>
 <body>
     <div class="countdown-banner sticky">

--- a/promo-armacoes49.html
+++ b/promo-armacoes49.html
@@ -25,7 +25,7 @@
     <link rel="stylesheet" href="assets/css/style.css">
     <script src="https://cdnjs.cloudflare.com/ajax/libs/modernizr/3.13.1/modernizr.min.js"></script>
     <!-- Script do Google reCAPTCHA v3 -->
-    <script src="https://www.google.com/recaptcha/api.js?render=6LfqMsYrAAAAAOXpg4f5HpKyW71cRDhqfeAoRt2J"></script>
+    <script src="https://www.google.com/recaptcha/api.js?render=6LcFeM8rAAAAAG_yvOemcZ1ivd14z9svaddS0Bk1"></script>
 </head>
 <body>
     <div class="countdown-banner sticky">

--- a/promo-oculos-antigo.html
+++ b/promo-oculos-antigo.html
@@ -25,7 +25,7 @@
     <link rel="stylesheet" href="assets/css/style.css"> 
     <script src="https://cdnjs.cloudflare.com/ajax/libs/modernizr/3.13.1/modernizr.min.js"></script>
     <!-- Script do Google reCAPTCHA v3 -->
-    <script src="https://www.google.com/recaptcha/api.js?render=6LfqMsYrAAAAAOXpg4f5HpKyW71cRDhqfeAoRt2J"></script>
+    <script src="https://www.google.com/recaptcha/api.js?render=6LcFeM8rAAAAAG_yvOemcZ1ivd14z9svaddS0Bk1"></script>
 </head>
 <body>
     <div class="countdown-banner sticky">

--- a/promo70.html
+++ b/promo70.html
@@ -25,7 +25,7 @@
     <link rel="stylesheet" href="assets/css/style.css">
     <script src="https://cdnjs.cloudflare.com/ajax/libs/modernizr/3.13.1/modernizr.min.js"></script>
     <!-- Script do Google reCAPTCHA v3 -->
-    <script src="https://www.google.com/recaptcha/api.js?render=6LfqMsYrAAAAAOXpg4f5HpKyW71cRDhqfeAoRt2J"></script>
+    <script src="https://www.google.com/recaptcha/api.js?render=6LcFeM8rAAAAAG_yvOemcZ1ivd14z9svaddS0Bk1"></script>
 </head>
 <body>
     <div class="countdown-banner sticky">


### PR DESCRIPTION
Updated the reCAPTCHA v3 site key in all promotional landing pages to resolve "Invalid site key" errors. The old key was replaced with the new, valid key in all files matching the pattern "promo-*.html".